### PR TITLE
Processing around custom fields

### DIFF
--- a/example/server.ts
+++ b/example/server.ts
@@ -17,7 +17,7 @@ const client = new UserVoice.Client({
 client.loginAsOwner()
   .then(ownerClient => {
     const example = new Example(ownerClient);
-    example.listTickets();
+    example.getCustomFields();
   });
 
 class Example {
@@ -32,16 +32,18 @@ class Example {
       email: 'testuser@test123498888391.com',
       name: 'Test User',
       ticket: {
-        created_at: new Date(2014, 0, 0, 0, 0, 0, 0),
         custom_field_values: {
-          'test-key': 'test-value'
+          'Project': 'My Project'
         },
         message: 'This is the body',
         state: 'open',
-        subject: 'Test Ticket',
-        updated_at: new Date(2014, 0, 0, 0, 0, 0, 0)
+        subject: 'Test Ticket'
       }
     }));
+  }
+
+  public getCustomFields() {
+    return this.defaultPromiseHandler(this.uvClient.customFieldService.list());
   }
 
   public createMessage() {
@@ -97,7 +99,7 @@ class Example {
       ticket: {
         created_at: new Date(2012, 1, 1, 0, 0, 0, 0),
         custom_field_values: {
-          'my-field': 'my-value'
+          'Project': 'My Project'
         },
         subject: 'Some edits',
         updated_at: new Date(2012, 1, 1, 0, 0, 0, 0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uservoice-nodejs",
-  "version": "1.0.11",
+  "version": "0.0.11",
   "description": "Node.js SDK for UserVoice",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/src/v1/api/models/customField.ts
+++ b/src/v1/api/models/customField.ts
@@ -1,0 +1,25 @@
+import {IListResponse, IRequestOptions, IModel} from './model';
+
+export interface ICustomFieldListRequest extends IRequestOptions {
+  updated_after_date?: Date;
+}
+
+export interface ICustomFieldListResponse extends IListResponse {
+  custom_fields: ICustomField[];
+}
+
+export interface ICustomField extends IModel {
+  name: string;
+  description: string;
+  activate: boolean;
+  private: boolean;
+  predefined: boolean;
+  read_only: boolean;
+  allow_blank?: boolean;
+  possible_values?: IPossibleCustomFieldValue[];
+}
+
+export interface IPossibleCustomFieldValue extends IModel {
+  value: string;
+  active: boolean;
+}

--- a/src/v1/api/services/customFieldService.ts
+++ b/src/v1/api/services/customFieldService.ts
@@ -1,0 +1,13 @@
+import * as Promise from 'bluebird';
+import {ApiService} from './apiService';
+import {ICustomFieldListRequest, ICustomFieldListResponse} from '../models/customField';
+
+export class CustomFieldService extends ApiService {
+  public list(data: ICustomFieldListRequest = {}): Promise<ICustomFieldListResponse> {
+    return this.client.get<ICustomFieldListResponse>(`custom_fields.json`, data);
+  }
+
+  public public(data: ICustomFieldListRequest = {}): Promise<ICustomFieldListResponse> {
+    return this.client.get<ICustomFieldListResponse>(`custom_fields/public.json`, data);
+  }
+}

--- a/src/v1/api/services/ticketService.ts
+++ b/src/v1/api/services/ticketService.ts
@@ -1,6 +1,6 @@
 import * as Promise from 'bluebird';
 import {IRequestOptions} from '../models/model';
-import {ITicketResponse, ITicketListResponse, ITicketCreateRequest, ITicketUpdateRequest} from '../models/ticket';
+import {ITicketResponse, ITicketListResponse, ITicketCreateRequest, ITicketUpdateRequest, ITicket} from '../models/ticket';
 import {ApiService} from './apiService';
 
 export class TicketService extends ApiService {
@@ -9,11 +9,13 @@ export class TicketService extends ApiService {
       throw new Error('Not authorized to create ticket; must login first.');
     }
 
-    return this.client.post<ITicketResponse>('tickets.json', data);
+    return this.client.post<ITicketResponse>('tickets.json', data)
+      .then(responseData => this.processTicketResponseCustomFields(responseData));
   }
 
   public update(ticketId: number, ticketData: ITicketUpdateRequest): Promise<ITicketResponse> {
-    return this.client.put<ITicketResponse>(`tickets/${ticketId}.json`, ticketData);
+    return this.client.put<ITicketResponse>(`tickets/${ticketId}.json`, ticketData)
+      .then(data => this.processTicketResponseCustomFields(data));
   }
 
   /**
@@ -21,14 +23,8 @@ export class TicketService extends ApiService {
    */
   public list(options: IRequestOptions = {}): Promise<ITicketListResponse> {
     options.per_page = options.per_page || this.client.requestOptions.pagination.max;
-    return this.client.get<ITicketListResponse>('tickets.json', options);
-  }
-
-  /**
-   * @link https://developer.uservoice.com/docs/api/reference/#_api_v1_custom_fields_get
-   */
-  public getCustomFields(includePublic: boolean): Promise<any> {
-    return this.client.get<any>(includePublic ? 'custom_fields/public.json' : 'custom_fields.json');
+    return this.client.get<ITicketListResponse>('tickets.json', options)
+      .then(data => this.processTicketListResponseCustomFields(data));
   }
 
   /**
@@ -40,7 +36,8 @@ export class TicketService extends ApiService {
     options.per_page = options.per_page || this.client.requestOptions.pagination.max;
     options.query = query;
 
-    return this.client.get<ITicketListResponse>('tickets/search.json', options);
+    return this.client.get<ITicketListResponse>('tickets/search.json', options)
+      .then(data => this.processTicketListResponseCustomFields(data));
   }
 
   /**
@@ -51,6 +48,30 @@ export class TicketService extends ApiService {
       throw new Error('ticketId cannot be empty');
     }
 
-    return this.client.get<ITicketResponse>(`tickets/${ticketId}.json`);
+    return this.client.get<ITicketResponse>(`tickets/${ticketId}.json`)
+      .then(data => this.processTicketResponseCustomFields(data));
+  }
+
+  private processTicketResponseCustomFields(ticketResponse: ITicketResponse) {
+    this.convertCustomFieldsToObject(ticketResponse.ticket);
+    return ticketResponse;
+  }
+
+  private processTicketListResponseCustomFields(ticketListResponse: ITicketListResponse) {
+    ticketListResponse.tickets.forEach(t => this.convertCustomFieldsToObject(t));
+    return ticketListResponse;
+  }
+
+  private convertCustomFieldsToObject(ticket: ITicket) {
+    if (!ticket.custom_fields) { return; }
+
+    const object: { [key: string]: string} = {};
+
+    const rawCustomFields: { key: string; value: string }[] = ticket.custom_fields as any;
+    rawCustomFields.forEach(customField => {
+      object[customField.key] = customField.value;
+    });
+
+    ticket.custom_fields = object;
   }
 }

--- a/src/v1/client.ts
+++ b/src/v1/client.ts
@@ -3,6 +3,7 @@ import * as querystring from 'querystring';
 import {TicketService} from './api/services/ticketService';
 import {TicketMessageService} from './api/services/ticketMessageService';
 import {TicketNoteService} from './api/services/ticketNoteService';
+import {CustomFieldService} from './api/services/customFieldService';
 import {AssetService} from './api/services/assetService';
 import {IOAuthProvider, IOAuthConsumer, OAuthProvider} from './oauthProvider';
 import {IRequestOptions} from './api/models/model';
@@ -15,6 +16,7 @@ export class Client {
   public ticketMessageService = new TicketMessageService(this);
   public ticketNoteService = new TicketNoteService(this);
   public ticketAssetService = new AssetService(this);
+  public customFieldService = new CustomFieldService(this);
   private baseUrl: string;
 
   constructor(private clientOptions: IClientOptions, private oAuthProviderInstance: IOAuthProvider = new OAuthProvider()) {

--- a/tests/ticketService.spec.ts
+++ b/tests/ticketService.spec.ts
@@ -1,4 +1,5 @@
 import * as chai from 'chai';
+import * as moment from 'moment';
 import {Client} from '../src/v1/client';
 import {TicketService} from '../src/v1/api/services/ticketService';
 import {FakeOAuthProvider, IResponseOptions} from './fixtures';
@@ -14,23 +15,23 @@ const ticketData = {
 
 /**
  * Sample return data from ticket API
- * Useful for methods that call Ticket.fromApi
  */
-const apiTicketData = {
-  created_at: '2016-01-01T00:00:000Z',
-  created_by: 'created_by',
-  custom_fields: [{
-    'key1': 'value1'
-  }],
-  id: 'id',
-  last_message_at: '2016-01-01T00:00:000Z',
-  state: 'state',
-  subject: 'subject',
-  ticket_number: 'ticket_number',
-  updated_by: 'updated_by'
-};
+let apiTicketData: any = null;
 
 describe('[Unit Tests]', () => {
+  beforeEach(() => {
+    apiTicketData = {
+      created_at: moment('2016-01-01T00:00:000Z').toDate(),
+      custom_fields: [
+        { key: 'key1', value: 'value1' }
+      ],
+      id: 1,
+      state: 'state',
+      subject: 'subject',
+      ticket_number: 1
+    };
+  });
+
   describe('Tickets', () => {
     describe('Create', () => {
       it('should post ticket data', () => {
@@ -53,6 +54,19 @@ describe('[Unit Tests]', () => {
 
         return tickets.create(ticketData)
           .catch(error => chai.assert.strictEqual(error, errorMessage));
+      });
+    });
+
+    describe('Show', () => {
+      it('should process custom_fields into hash-like object', () => {
+        const tickets = buildTickets({
+          get: { data: { ticket: apiTicketData } }
+        });
+
+        return tickets.show(1)
+          .then(data => {
+            chai.assert.strictEqual(data.ticket.custom_fields['key1'], 'value1');
+          });
       });
     });
   });

--- a/tslint.json
+++ b/tslint.json
@@ -54,7 +54,7 @@
     "no-reference": true,
     "no-require-imports": false,
     "no-shadowed-variable": true,
-    "no-string-literal": true,
+    "no-string-literal": false,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unreachable": true,


### PR DESCRIPTION
- Process custom fields from the array format they come down into a more idiomatic associative array/dictionary/hashmap
- Extract a customFieldService for custom fields endpoint (doesn't belong in ticketService)
- Create test for custom field processing
- Add example for custom fields list
